### PR TITLE
Update npc_services_00.sql

### DIFF
--- a/data/sql/db-world/npc_services_00.sql
+++ b/data/sql/db-world/npc_services_00.sql
@@ -1,10 +1,11 @@
-DELETE FROM `creature_template` WHERE `entry` = 55002;
-
 Set @NpcName = "Services NPC",
     @NpcSubname = "AzerothCore",
     @NpcEntry = 55002,
     @NpcDisplayID = 31833,
     @NpcLevel = 80;
 
-INSERT INTO `creature_template` (`entry`, `modelid1`, `name`, `subname`, `minlevel`, `maxlevel`, `faction`, `npcflag`, `speed_walk`, `speed_run`, `scale`, `rank`, `dmgschool`, `BaseAttackTime`, `RangeAttackTime`, `unit_class`, `unit_flags`, `unit_flags2`, `dynamicflags`, `family`, `trainer_type`, `trainer_spell`, `trainer_class`, `trainer_race`, `type`, `type_flags`, `lootid`, `pickpocketloot`, `skinloot`, `PetSpellDataId`, `VehicleId`, `mingold`, `maxgold`, `AIName`, `MovementType`, `HoverHeight`, `HealthModifier`, `ManaModifier`, `ArmorModifier`, `RacialLeader`, `movementId`, `RegenHealth`, `mechanic_immune_mask`, `flags_extra`, `ScriptName`, `VerifiedBuild`) VALUES
-(@NpcEntry, @NpcDisplayID, @NpcName, @NpcSubname, @NpcLevel, @NpcLevel, 35, 1, 1, 1.14286, 1, 1, 0, 2000, 2000, 2, 0, 2048, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, '', 0, 1, 50, 50, 1, 0, 0, 1, 0, 0, 'mod_npc_services', 12340);
+DELETE FROM `creature_template` WHERE `entry` = @NpcEntry;
+INSERT INTO `creature_template` (`entry`, `name`, `subname`, `IconName`, `gossip_menu_id`, `minlevel`, `maxlevel`, `exp`, `faction`, `npcflag`, `scale`, `rank`, `dmgschool`, `BaseAttackTime`, `RangeAttackTime`, `unit_class`, `unit_flags`, `unit_flags2`, `type`, `type_flags`, `lootid`, `pickpocketloot`, `skinloot`, `AIName`, `MovementType`, `HoverHeight`, `RacialLeader`, `movementId`, `HealthModifier`, `ManaModifier`, `ArmorModifier`, `RegenHealth`, `mechanic_immune_mask`, `flags_extra`, `ScriptName`) VALUES (@NpcEntry, @NpcName, @NpcSubname, NULL, 0, @NpcLevel, @NpcLevel, 2, 35, 1, 1, 1, 0, 2000, 2000, 2, 0, 2048, 7, 0, 0, 0, 0, '', 0, 1, 0, 0, 50, 50, 1, 1, 0, 0, 'mod_npc_services');
+
+DELETE FROM `creature_template_model` WHERE `CreatureID` = @NpcEntry;
+INSERT INTO `creature_template_model` (`CreatureID`, `Idx`, `CreatureDisplayID`, `DisplayScale`, `Probability`, `VerifiedBuild`) VALUES (@NpcEntry, 0, @NpcDisplayID, 1, 1, 12340);


### PR DESCRIPTION
Corrected insert statements to match the current database format separating creature_template_model information into it's own insert statement.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Current database world database format breaks the model information out into it's own table.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes issue 24 - https://github.com/azerothcore/mod-npc-services/issues/24

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

- tested on Debian 12 and AzerothCore rev. ee8c103d3d9b 2024-08-02 19:21:21 +0000 (master branch) (Unix, RelWithDebInfo, Static)



## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. On a fresh deploy of AzerothCore import the sql file.

