### PR TITLE
fix: remove deprecated creature_template columns from SQL

### DIFF
--- a/data/sql/db-world/npc_services_00.sql
+++ b/data/sql/db-world/npc_services_00.sql
@@ -5,7 +5,7 @@ Set @NpcName = "Services NPC",
     @NpcLevel = 80;
 
 DELETE FROM `creature_template` WHERE `entry` = @NpcEntry;
-INSERT INTO `creature_template` (`entry`, `name`, `subname`, `IconName`, `gossip_menu_id`, `minlevel`, `maxlevel`, `exp`, `faction`, `npcflag`, `scale`, `rank`, `dmgschool`, `BaseAttackTime`, `RangeAttackTime`, `unit_class`, `unit_flags`, `unit_flags2`, `type`, `type_flags`, `lootid`, `pickpocketloot`, `skinloot`, `AIName`, `MovementType`, `HoverHeight`, `RacialLeader`, `movementId`, `HealthModifier`, `ManaModifier`, `ArmorModifier`, `RegenHealth`, `mechanic_immune_mask`, `flags_extra`, `ScriptName`) VALUES (@NpcEntry, @NpcName, @NpcSubname, NULL, 0, @NpcLevel, @NpcLevel, 2, 35, 1, 1, 1, 0, 2000, 2000, 2, 0, 2048, 7, 0, 0, 0, 0, '', 0, 1, 0, 0, 50, 50, 1, 1, 0, 0, 'mod_npc_services');
+INSERT INTO `creature_template` (`entry`, `name`, `subname`, `IconName`, `gossip_menu_id`, `minlevel`, `maxlevel`, `exp`, `faction`, `npcflag`, `rank`, `dmgschool`, `BaseAttackTime`, `RangeAttackTime`, `unit_class`, `unit_flags`, `unit_flags2`, `type`, `type_flags`, `lootid`, `pickpocketloot`, `skinloot`, `AIName`, `MovementType`, `HoverHeight`, `RacialLeader`, `movementId`, `HealthModifier`, `ManaModifier`, `ArmorModifier`, `RegenHealth`, `flags_extra`, `ScriptName`) VALUES(@NpcEntry, @NpcName, @NpcSubname, NULL, 0, @NpcLevel, @NpcLevel, 2, 35, 1, 1, 0, 2000, 2000, 2, 0, 2048, 7, 0, 0, 0, 0, '', 0, 1, 0, 0, 50, 50, 1, 1, 0, 'mod_npc_services');
 
 DELETE FROM `creature_template_model` WHERE `CreatureID` = @NpcEntry;
 INSERT INTO `creature_template_model` (`CreatureID`, `Idx`, `CreatureDisplayID`, `DisplayScale`, `Probability`, `VerifiedBuild`) VALUES (@NpcEntry, 0, @NpcDisplayID, 1, 1, 12340);


### PR DESCRIPTION
## Summary
- Removes `scale`, `mechanic_immune_mask`, and/or `spell_school_immune_mask` columns from `creature_template` INSERT/UPDATE statements
- These columns were removed from AzerothCore's `creature_template` table:
  - `scale` → moved to `creature_template_model.DisplayScale`
  - `mechanic_immune_mask`/`spell_school_immune_mask` → replaced by `CreatureImmunitiesId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)